### PR TITLE
Add this site to the DAP itself

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -251,4 +251,6 @@
     </div>
   </body>
   <script src="../js/index.js"></script>
+
+  <script id="_fed_an_ua_tag" src="https://analytics.usa.gov/dap/dap.min.js"></script>
 </html>


### PR DESCRIPTION
This adds the site to the DAP, using the hosted DAP snippet I added after #105. The tag is:

```html
<script id="_fed_an_ua_tag" src="https://analytics.usa.gov/dap/dap.min.js"></script>
```

Two notes:

* The page cannot be running at `localhost`, or an error is thrown. It does some brittle domain-splitting that throws an error. I used `ngrok` to create a "normal-looking" domain so that it would work. This should become an upstream issue for the team maintaining the DAP snippet.
* The `id` attribute is required, or an error is thrown. I'm not sure why it is required.

Fixes #81.