### PR TITLE
Adds a message to the console

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -250,7 +250,29 @@
 
     </div>
   </body>
+
+
+  <!--
+    IE detection, used to guide console formatting in subsequent include
+  -->
+  <script type="text/javascript">window._ie9 = false;</script>
+
+  <!--[if IE 9 ]>
+    <script type="text/javascript">window._ie9 = true;</script>
+  <![endif]-->
+
+  <!--
+   IE10 JS targeting: http://stackoverflow.com/a/17099988
+   IE11 JS targeting: http://stackoverflow.com/a/17447695
+  -->
+  <script type="text/javascript">
+    window._ie10 = ("onpropertychange" in document && !!window.matchMedia);
+    window._ie11 = !!navigator.userAgent.match(/Trident\/7.0; rv 11/);
+    window._ie = window._ie9 || window._ie10 || window._ie11;
+  </script>
+
   <script src="../js/index.js"></script>
 
+  <!-- This is all it takes to report an agency's traffic to the DAP. -->
   <script id="_fed_an_ua_tag" src="https://analytics.usa.gov/dap/dap.min.js"></script>
 </html>

--- a/js/index.js
+++ b/js/index.js
@@ -758,4 +758,29 @@
     parent.node().appendChild(child.node());
   }
 
+  // friendly console message
+
+  if (window._ie) {
+    console.log("Hi! Please poke around to your heart's content.");
+    console.log("");
+    console.log("If you find a bug or something, please report it at https://github.com/GSA/analytics.usa.gov/issues");
+    console.log("This is an open source, public domain project, and your contributions are very welcome.");
+  }
+
+  // otherwise, let's get fancy
+  else {
+    var styles = {
+      big: "font-size: 24pt; font-weight: bold;",
+      medium: "font-size: 10pt",
+      medium_bold: "font-size: 10pt; font-weight: bold",
+      medium_link: "font-size: 10pt; font-weight: bold; color: #18f",
+    };
+    console.log("%cHi! Please poke around to your heart's content.", styles.big);
+    console.log(" ");
+    console.log("%cIf you find a bug or something, please report it over at %chttps://github.com/GSA/analytics.usa.gov/issues", styles.medium, styles.medium_link);
+    console.log("%cThis is an open source, public domain project, and your contributions are very welcome.", styles.medium);
+
+  }
+
+
 })(this);


### PR DESCRIPTION
This adds a nice little message to the developer console, for anyone who pokes around:

![screenshot from 2015-01-18 21 56 58](https://cloud.githubusercontent.com/assets/4592/5795391/12ad48c4-9f5d-11e4-8b97-67daf5080dc4.png)

It degrades to plaintext formatting on IE9, 10, and 11 (using some simple user agent detection stuff), where the `%c` trick isn't supported. It should work well on Chrome and Firefox.

Fixes #82.