### PR TITLE
Tweak copy, and copy spacing

### DIFF
--- a/css/public_analytics.css
+++ b/css/public_analytics.css
@@ -215,7 +215,7 @@ section {
 
 #explanation, #data_download, #agencies {
   border-top: 1px solid #aaa;
-  line-height: 1.3em; }
+  line-height: 1.6em; }
   #explanation li, #data_download li, #agencies li {
     margin: 1em 0; }
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -176,7 +176,7 @@
         </p>
 
         <p>
-          <strong>Top 20 data:</strong> "Now" data includes traffic to a specific, single page &mdash; whereas "7 Days" and "30 Days" data includes traffic to a domain <strong>and</strong> all pages within that domain.
+          <strong>Top 20 data:</strong> "Now" data includes traffic to a specific, single page&mdash;whereas "7 Days" and "30 Days" data includes traffic to a domain <strong>and</strong> all pages within that domain.
         </p>
 
         <p>

--- a/demo/index.html
+++ b/demo/index.html
@@ -168,14 +168,15 @@
       <section id="explanation">
         <h3>About this Site</h3>
         <p>
-          This data provides a window into how people are interacting with the government online. The data comes from a unified Google Analytics account for U.S. federal government agencies known as the <a href="https://www.digitalgov.gov/services/dap/">Digital Analytics Program</a>. This program helps government agenices understand how people find, access, and use government services online. The program does not collect any personal information about individual users.
+          This data provides a window into how people are interacting with the government online. The data comes from a unified Google Analytics account for U.S. federal government agencies known as the <a href="https://www.digitalgov.gov/services/dap/">Digital Analytics Program</a>. This program helps government agenices understand how people find, access, and use government services online. The program does not track individuals, and <a href="https://support.google.com/analytics/answer/2763052?hl=en">anonymizes the IP addresses</a> of visitors.
         </p>
 
         <p>
           Not every government website is represented in this data. Currently, the Digital Analytics Program collects web traffic from almost 300 executive branch government domains out of <a href="https://catalog.data.gov/dataset/gov-domains-api">about 1,350 domains</a> total. This data is not a representative sample of all web traffic to government domains.
         </p>
 
-        <p><strong>Top 20 data:</strong> "Now" data includes traffic to a specific, single page, whereas "7 Days" and "30 Days" data includes traffic to a domain AND all pages within that domain. This is how the Google Analytics API releases the data.
+        <p>
+          <strong>Top 20 data:</strong> "Now" data includes traffic to a specific, single page &mdash; whereas "7 Days" and "30 Days" data includes traffic to a domain <strong>and</strong> all pages within that domain.
         </p>
 
         <p>
@@ -183,7 +184,7 @@
         </p>
 
         <p>
-          We plan to expand and document the data made available here. If you have any suggestions, or spot any issues or bugs, please <a href="https://github.com/GSA/analytics.usa.gov/issues">open an issue on GitHub</a> or contact the <a href="mailto:DAP@gsa.gov">Digital Analytics Program</a>.
+          We plan to expand the data made available here. If you have any suggestions, or spot any issues or bugs, please <a href="https://github.com/GSA/analytics.usa.gov/issues">open an issue on GitHub</a> or contact the <a href="mailto:DAP@gsa.gov">Digital Analytics Program</a>.
         </p>
       </section>
 

--- a/sass/public_analytics.css.scss
+++ b/sass/public_analytics.css.scss
@@ -217,7 +217,7 @@ section {
 
 #explanation, #data_download, #agencies {
   border-top: $border_width solid $gray;
-  line-height: 1.3em;
+  line-height: 1.6em;
   li {
     margin: 1em 0;
   }


### PR DESCRIPTION
Makes some copy changes to the About section, and spaces the text out a little better:

![copy](https://cloud.githubusercontent.com/assets/4592/5796573/815e978a-9f78-11e4-8e8d-cbf23a5f200c.png)

This addresses my concern in https://github.com/GSA/analytics.usa.gov/pull/97#issuecomment-70382915 and fixes #80.