### PR TITLE
Make the big number real

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -90,7 +90,9 @@
           <h3>Visits in the Past 90 Days</h3>
         </section>
 
-        <section class="section_subheadline">There were <span id="total_visitors">1.05 billion</span> visits over the past 90 days.</section>
+        <section class="section_subheadline">
+          There were <span id="total_visitors" class="data">...</span> visits over the past 90 days.
+        </section>
 
         <section id="devices" class="three_column"
           data-block="devices"

--- a/js/index.js
+++ b/js/index.js
@@ -117,6 +117,11 @@
         .value(function(d) { return d.share * 100; })
         .format(formatPercent))
       .on("render", function(selection, data) {
+        /*
+         * XXX this is an optimization. Rather than loading
+         * users.json, we total up the device numbers to get the "big
+         * number", saving us an extra XHR load.
+         */
         var total = d3.sum(data.map(function(d) { return d.value; }));
         d3.select("#total_visitors")
           .text(formatBigNumber(total));

--- a/js/index.js
+++ b/js/index.js
@@ -4,12 +4,8 @@
   var formatCommas = d3.format(","),
       parseDate = d3.time.format("%Y-%m-%d").parse,
       formatDate = d3.time.format("%A, %b %e"),
-      formatVisits = (function() {
-        var suffixes = {
-          "k": ["k", 1], // thousands
-          "M": ["m", 1], // millions
-          "G": ["b", 2]  // billions
-        };
+      formatPrefix = function(suffixes) {
+        if (!suffixes) return formatCommas;
         return function(visits) {
           var prefix = d3.formatPrefix(visits),
               suffix = suffixes[prefix.symbol];
@@ -19,7 +15,16 @@
                 .replace(/\.0+$/, "") + suffix[0]
             : formatCommas(visits);
         };
-      })(),
+      },
+      formatVisits = formatPrefix({
+        "k": ["k", 1], // thousands
+        "M": ["m", 1], // millions
+        "G": ["b", 2]  // billions
+      }),
+      formatBigNumber = formatPrefix({
+        "M": [" million", 1], // millions
+        "G": [" billion", 2]  // billions
+      }),
       trimZeroes = function(str) {
         return str.replace(/\.0+$/, '');
       },
@@ -110,7 +115,12 @@
       })
       .render(barChart()
         .value(function(d) { return d.share * 100; })
-        .format(formatPercent)),
+        .format(formatPercent))
+      .on("render", function(selection, data) {
+        var total = d3.sum(data.map(function(d) { return d.value; }));
+        d3.select("#total_visitors")
+          .text(formatBigNumber(total));
+      }),
 
     // the browsers block is a table
     "browsers": renderBlock()


### PR DESCRIPTION
Fixes #57. Funnily enough, the real number right now is 1.06 billion, which is oddly close to the fake one.

In doing so, I generalized the visits formatting function so that we could easily make new ones with different suffixes. Rather than adding a new block that hits `users.json`, I added a "render" callback to the devices block that totals up the numbers and sticks the formatted number into `#total_visitors`. I stuck an ellipsis into that element so that the fake number doesn't show up while the data is loading.