### PR TITLE
Link to the DAP's privacy permalink

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -188,7 +188,7 @@
       <section id="explanation">
         <h3>About this Site</h3>
         <p>
-          This data provides a window into how people are interacting with the government online. The data comes from a unified Google Analytics account for U.S. federal government agencies known as the <a href="https://www.digitalgov.gov/services/dap/">Digital Analytics Program</a>. This program helps government agenices understand how people find, access, and use government services online. The program does not track individuals, and <a href="https://support.google.com/analytics/answer/2763052?hl=en">anonymizes the IP addresses</a> of visitors.
+          This data provides a window into how people are interacting with the government online. The data comes from a unified Google Analytics account for U.S. federal government agencies known as the <a href="https://www.digitalgov.gov/services/dap/">Digital Analytics Program</a>. This program helps government agenices understand how people find, access, and use government services online. The program <a href="https://www.digitalgov.gov/services/dap/common-questions-about-dap-faq/#part-4">does not track individuals</a>, and <a href="https://support.google.com/analytics/answer/2763052?hl=en">anonymizes the IP addresses</a> of visitors.
         </p>
 
         <p>


### PR DESCRIPTION
Links the About text to the [DAP's privacy FAQ section](http://www.digitalgov.gov/services/dap/common-questions-about-dap-faq/#part-4).

Fixes #123.