### PR TITLE
Allow for exception page titles

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -6,7 +6,10 @@
   var exceptions = {
     // for the Now tab
     "applicationmanager.gov/application.aspx": "https://applicationmanager.gov",
-    "forecast.weather.gov/mapclick.php": "http://www.weather.gov/",
+    "forecast.weather.gov/mapclick.php": {
+      "page": "http://www.weather.gov/",
+      "page_title": "National Weather Service - Map of Forecast Area"
+    },
     "egov.uscis.gov/casestatus/mycasestatus.do": "https://egov.uscis.gov/casestatus/",
     "irs.gov/individuals/electronic-filing-pin-request": " http://www.irs.gov/Individuals/Electronic-Filing-PIN-Request",
     "ebenefits.va.gov/ebenefits-portal/ebenefits.portal": "https://www.ebenefits.va.gov/ebenefits-portal/ebenefits.portal",
@@ -182,11 +185,17 @@
           .html("")
           .append("a")
             .attr("target", "_blank")
+            .attr("title", function(d) {
+              var except = exceptions[d.domain];
+              return except && except.page_title || d.domain;
+            })
             .attr("href", function(d) {
-              return exceptions[d.domain] || ("http://" + d.domain);
+              var except = exceptions[d.domain];
+              return except && except.page || except || ("http://" + d.domain);
             })
             .text(function(d) {
-              return d.domain;
+              var except = exceptions[d.domain];
+              return except && except.page_title || d.domain;
             });
       })
       .render(barChart()
@@ -215,13 +224,16 @@
           .append("a")
             .attr("target", "_blank")
             .attr("title", function(d) {
-              return d.page_title;
+              var except = exceptions[d.page];
+              return except && except.page_title || d.page_title;
             })
             .attr("href", function(d) {
-              return exceptions[d.page] || ("http://" + d.page);
+              var except = exceptions[d.page];
+              return except && except.page || except || ("http://" + d.page);
             })
             .text(function(d) {
-              return d.page_title;
+              var except = exceptions[d.page];
+              return except && except.page_title || d.page_title;
             });
       })
       .render(barChart()


### PR DESCRIPTION
Currently exceptions override page urls or domains but not page titles. This adds the option to set an exception object that specifies both a `page` and `page_title`. It's implemented on the weather map to avoid matching items:

### Before
![screen shot 2015-02-27 at 12 21 26 pm](https://cloud.githubusercontent.com/assets/170641/6417480/a0e3246e-be7b-11e4-8f13-76d41e717ee4.png)

### After
![screen shot 2015-02-27 at 12 25 16 pm](https://cloud.githubusercontent.com/assets/170641/6417492/b4abf1ba-be7b-11e4-9a4f-510d3d6e32ae.png)


Since these pages don't have a unique title, I borrowed from the link's `title`.

![screen shot 2015-02-27 at 12 02 27 pm](https://cloud.githubusercontent.com/assets/170641/6417502/bf1c5f86-be7b-11e4-9ffb-b030f89b95a8.png)

Also adds missing title attribute to links for the realtime list.
