### PR TITLE
A more proper Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
-scss ?= sass/public_analytics.css.scss
-css ?= css/public_analytics.css
+SASS_DIR=sass
+CSS_DIR=css
+scss ?= $(SASS_DIR)/public_analytics.css.scss
+css ?= $(CSS_DIR)/public_analytics.css
 
-all: styles
+# These targets don't actually build a file.
+.PHONY: all watch clean
 
-styles:
-	sass $(scss):$(css)
+all: $(css)
+
+$(CSS_DIR)/%.css: $(SASS_DIR)/%.css.scss
+	sass $<:$@
 
 watch:
 	sass --watch $(scss):$(css)

--- a/README.md
+++ b/README.md
@@ -22,13 +22,6 @@ make watch
 make clean all
 ```
 
-or:
-
-```bash
-# -B tells make to run even if the .css file exists
-make -B
-```
-
 ### Deploying the app
 
 To deploy this app to `analytics.usa.gov`, you will need authorized access to 18F's Amazon S3 bucket for the project.


### PR DESCRIPTION
* SCSS files are declared as required dependencies to build CSS files, and are
  used as input to the sass command
* The targets that don't actually build a file are declared as PHONY

===

The idea here is to turn the Makefile into more than just a glorified bash script. Now it will properly check if the primary dependency of the CSS file (the SCSS file) has changed and only build it accordingly.

Additionally this provides some "pre-factoring" of the file, in case there are more .css files in the future.

I guess I should admit that I realize that most times this will be run in "watch" mode, so proper dependency checking is probably irrelevant.