### PR TITLE
Add a 'serve' make command for local testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,5 +9,8 @@ styles:
 watch:
 	sass --watch $(scss):$(css)
 
+serve:
+	make all && python -m SimpleHTTPServer 8000
+
 clean:
 	rm -f $(css)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ or:
 make -B
 ```
 
+* To serve the site locally for testing, run:
+
+```bash
+make serve
+```
+
+Then navigate to localhost:8000 in your browser of choice
+
 ### Deploying the app
 
 To deploy this app to `analytics.usa.gov`, you will need authorized access to 18F's Amazon S3 bucket for the project.


### PR DESCRIPTION
A new contributor trying to work on this code will quickly run into the issue of the static files needing to be served through an HTTP server. This gives a quick cheap option for doing so locally.