### PR TITLE
Convert site to use Jekyll, allow for local data hosting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gem 'jekyll'
+
+gem 'bourbon'
+gem 'sass'
+gem 'neat'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,80 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    blankslate (2.1.2.4)
+    bourbon (4.2.1)
+      sass (~> 3.4)
+      thor
+    celluloid (0.16.0)
+      timers (~> 4.0.0)
+    classifier-reborn (2.0.3)
+      fast-stemmer (~> 1.0)
+    coffee-script (2.3.0)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.9.1)
+    colorator (0.1)
+    execjs (2.4.0)
+    fast-stemmer (1.0.2)
+    ffi (1.9.8)
+    hitimes (1.2.2)
+    jekyll (2.5.3)
+      classifier-reborn (~> 2.0)
+      colorator (~> 0.1)
+      jekyll-coffeescript (~> 1.0)
+      jekyll-gist (~> 1.0)
+      jekyll-paginate (~> 1.0)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 2.6.1)
+      mercenary (~> 0.3.3)
+      pygments.rb (~> 0.6.0)
+      redcarpet (~> 3.1)
+      safe_yaml (~> 1.0)
+      toml (~> 0.1.0)
+    jekyll-coffeescript (1.0.1)
+      coffee-script (~> 2.2)
+    jekyll-gist (1.1.0)
+    jekyll-paginate (1.1.0)
+    jekyll-sass-converter (1.3.0)
+      sass (~> 3.2)
+    jekyll-watch (1.2.1)
+      listen (~> 2.7)
+    kramdown (1.6.0)
+    liquid (2.6.2)
+    listen (2.9.0)
+      celluloid (>= 0.15.2)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+    mercenary (0.3.5)
+    neat (1.7.2)
+      bourbon (>= 4.0)
+      sass (>= 3.3)
+    parslet (1.5.0)
+      blankslate (~> 2.0)
+    posix-spawn (0.3.10)
+    pygments.rb (0.6.2)
+      posix-spawn (~> 0.3.6)
+      yajl-ruby (~> 1.2.0)
+    rb-fsevent (0.9.4)
+    rb-inotify (0.9.5)
+      ffi (>= 0.5.0)
+    redcarpet (3.1.2)
+    safe_yaml (1.0.4)
+    sass (3.4.13)
+    thor (0.19.1)
+    timers (4.0.1)
+      hitimes
+    toml (0.1.2)
+      parslet (~> 1.5.0)
+    yajl-ruby (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bourbon
+  jekyll
+  neat
+  sass

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,5 @@ styles:
 watch:
 	sass --watch $(scss):$(css)
 
-serve:
-	make all && python -m SimpleHTTPServer 8000
-
 clean:
 	rm -f $(css)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ To compile the Sass stylesheets once, run `make clean all`, or `make -B` to comp
 
 The development settings assume data is available at `http://localhost:3000`.
 
-If also working off of local data, e.g. using `analytics-reporter`, you will need to make the data available over HTTP and CORS. It's recommended to use the Node module `serve`:
+If also working off of local data, e.g. using `analytics-reporter`, you will need to make the data available over HTTP _and_ through CORS.
+
+Various tools can do this. This project recommends using the Node module `serve`:
 
 ```bash
 npm install -g serve

--- a/README.md
+++ b/README.md
@@ -57,19 +57,17 @@ The data will be available at `http://localhost:3000` over CORS, with no path pr
 
 ### Deploying the app to production
 
-In production, the site's base URL is set to `https://analytics.usa.gov` and the data's base URL is set to `https://analytics.usa.gov/data/live`. Build the site in production mode with:
+In production, the site's base URL is set to `https://analytics.usa.gov` and the data's base URL is set to `https://analytics.usa.gov/data/live`.
 
-```
-bundle exec jekyll build
-```
+To deploy this app to `analytics.usa.gov`, you will need authorized access to 18F's Amazon S3 bucket for the project.
 
-**18F/GSA only:** To deploy this app to `analytics.usa.gov`, you will need authorized access to 18F's Amazon S3 bucket for the project.
-
-If using `s3cmd`, the command to deploy the site with a **5 minute cache time** is:
+To deploy the site using `s3cmd`, production settings, and a **5 minute cache time**, run:
 
 ```bash
-s3cmd put --recursive -P --add-header="Cache-Control:max-age=300" _site/* s3://18f-dap/
+bundle exec jekyll build && s3cmd put --recursive -P --add-header="Cache-Control:max-age=300" _site/* s3://18f-dap/
 ```
+
+**Use the full command above.** The full command ensures that the build completes successfully, with production settings, _before_ triggering an upload to the production bucket.
 
 ### Fixing links in the Top 20
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To deploy this app to `analytics.usa.gov`, you will need authorized access to 18
 If using `s3cmd`, the command to deploy the site with a **5 minute cache time** is:
 
 ```bash
-s3cmd put --recursive -P --add-header="Cache-Control:max-age=300" *.html images data js css s3://18f-dap/
+s3cmd put --recursive -P --add-header="Cache-Control:max-age=300" _site/* s3://18f-dap/
 ```
 
 This deploys `index.html`, and the relevant static assets, to the bucket.

--- a/README.md
+++ b/README.md
@@ -1,53 +1,73 @@
-## Public analytics
+## analytics.usa.gov
 
-A collaboration to publish government website analytics.
+A project to publish website analytics for the US federal government.
 
-### Building the Stylesheets
+### Setup
 
-* Install [Sass](http://sass-lang.com/), Bourbon, and Neat:
+Ths app uses [Jekyll](http://jekyllrb.com) to build the site, and [Sass](http://sass-lang.com/), [Bourbon](http://bourbon.io), and [Neat](http://neat.bourbon.io) for CSS.
+
+Install them all:
 
 ```bash
-gem install sass bourbon neat
+bundle install
 ```
 
-* To watch the Sass source for changes and build the stylesheets automatically, run:
+### Developing locally
+
+Run Jekyll with development settings:
+
+```bash
+bundle exec jekyll serve --watch --config _.yml,_development.yml
+```
+
+Sass can watch the .scss source files for changes, and build the .css files automatically:
 
 ```bash
 make watch
 ```
 
-* To compile the Sass stylesheets once, run:
+To compile the Sass stylesheets once, run `make clean all`, or `make -B` to compile even if the .css file already exists.
+
+### Developing with local data
+
+The development settings assume data is available at `http://localhost:3000`.
+
+If also working off of local data, e.g. using `analytics-reporter`, you will need to make the data available over HTTP and CORS. It's recommended to use the Node module `serve`:
 
 ```bash
-make clean all
+npm install -g serve
 ```
 
-or:
+Generate data to a directory:
+
+```
+analytics --output [dir]
+```
+
+Then run `serve` from the output directory:
 
 ```bash
-# -B tells make to run even if the .css file exists
-make -B
+serve --cors
 ```
 
-* To serve the site locally for testing, run:
+The data will be available at `http://localhost:3000` over CORS, with no path prefix. For example, device data will be at `http://localhost:3000/devices.json`.
 
-```bash
-make serve
+
+### Deploying the app to production
+
+In production, the site's base URL is set to `https://analytics.usa.gov` and the data's base URL is set to `https://analytics.usa.gov/data/live`. Build the site in production mode with:
+
+```
+bundle exec jekyll build
 ```
 
-Then navigate to localhost:8000 in your browser of choice
-
-### Deploying the app
-
-To deploy this app to `analytics.usa.gov`, you will need authorized access to 18F's Amazon S3 bucket for the project.
+**18F/GSA only:** To deploy this app to `analytics.usa.gov`, you will need authorized access to 18F's Amazon S3 bucket for the project.
 
 If using `s3cmd`, the command to deploy the site with a **5 minute cache time** is:
 
 ```bash
 s3cmd put --recursive -P --add-header="Cache-Control:max-age=300" _site/* s3://18f-dap/
 ```
-
-This deploys `index.html`, and the relevant static assets, to the bucket.
 
 ### Fixing links in the Top 20
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,39 @@
+exclude:
+- ".jekyll-metadata"
+- ".gitignore"
+- ".travis.yml"
+- todo.txt
+- Gemfile
+- Gemfile.lock
+- Makefile
+- vendor
+- README.md
+- CONTRIBUTING.md
+- LICENSE.md
+- dap.md
+- uxtesting.md
+- work
+- ".sass-cache"
+
+# Site metadata
+title: "analytics.usa.gov | The US government's web traffic."
+description: "Official data on web traffic to hundreds of US federal government websites. Published by the Digital Analytics Program."
+
+# site's own URL, and data root
+# url: https://analytics.usa.gov
+# data_url: https://analytics.usa.gov/data/live
+
+# For development, when using `jekyll serve`
+url: http://localhost:4000
+# For development, when using:
+#   analytics --output=[dir]
+# and running from [dir]:
+#   serve
+data_url: http://localhost:3000
+
+# GitHub information
+org_name: GSA
+repo_name: analytics.usa.gov
+
+# twitter information
+twitter: usgsa

--- a/_config.yml
+++ b/_config.yml
@@ -20,16 +20,8 @@ title: "analytics.usa.gov | The US government's web traffic."
 description: "Official data on web traffic to hundreds of US federal government websites. Published by the Digital Analytics Program."
 
 # site's own URL, and data root
-# url: https://analytics.usa.gov
-# data_url: https://analytics.usa.gov/data/live
-
-# For development, when using `jekyll serve`
-url: http://localhost:4000
-# For development, when using:
-#   analytics --output=[dir]
-# and running from [dir]:
-#   serve
-data_url: http://localhost:3000
+url: https://analytics.usa.gov
+data_url: https://analytics.usa.gov/data/live
 
 # GitHub information
 org_name: GSA

--- a/_development.yml
+++ b/_development.yml
@@ -1,0 +1,7 @@
+# For development, when using `jekyll serve`
+url: http://localhost:4000
+# For development, when using:
+#   analytics --output=[dir]
+# and running from [dir]:
+#   serve
+data_url: http://localhost:3000

--- a/index.html
+++ b/index.html
@@ -1,3 +1,7 @@
+---
+permalink: /
+---
+
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -27,22 +31,22 @@
 
     <link rel="stylesheet" href="/css/public_analytics.css">
 
-    <meta name="twitter:site" content="@usgsa">
-    <meta name="twitter:creator" content="@usgsa">
+    <meta name="twitter:site" content="@{{ site.twitter }}">
+    <meta name="twitter:creator" content="@{{ site.twitter }}">
     <meta property="og:type" content="website" />
 
-    <meta property="og:url" content="https://analytics.usa.gov" />
-    <link rel="canonical" href="https://analytics.usa.gov" />
+    <meta property="og:url" content="{{ site.url }}" />
+    <link rel="canonical" href="{{ site.url }}" />
 
-    <title>analytics.usa.gov | The US government's web traffic.</title>
-    <meta property="og:title" content="analytics.usa.gov | The US government's web traffic." />
-    <meta property="og:site_name" content="analytics.usa.gov | The US government's web traffic." />
+    <title>{{ site.title }}</title>
+    <meta property="og:title" content="{{ site.title }}" />
+    <meta property="og:site_name" content="{{ site.title }}" />
 
-    <meta name="description" content="Official data on web traffic to hundreds of US federal government websites. Published by the Digital Analytics Program.">
-    <meta property="og:description" content="Official data on web traffic to hundreds of US federal government websites. Published by the Digital Analytics Program." />
+    <meta name="description" content="{{ site.description }}">
+    <meta property="og:description" content="{{ site.description }}" />
 
     <meta name="twitter:card" content="summary_large_image">
-    <meta property="og:image" content="https://analytics.usa.gov/images/share-image.png" />
+    <meta property="og:image" content="{{ site.url }}/images/share-image.png" />
 
 
 
@@ -89,7 +93,7 @@
       <div id="main_data">
         <section id="realtime"
           data-block="realtime"
-          data-source="https://analytics.usa.gov/data/live/realtime.json"
+          data-source="{{ site.data_url }}/realtime.json"
           data-refresh="15">
           <h2 id="current_visitors" class="data">...</h2>
           <div class="chart_subtitle">people on government websites now</div>
@@ -101,7 +105,7 @@
         </section>
         <section id="time_series"
           data-block="today"
-          data-source="https://analytics.usa.gov/data/live/today.json"
+          data-source="{{ site.data_url }}/today.json"
           data-refresh="15">
           <svg class="data time-series">
           </svg>
@@ -117,7 +121,7 @@
 
         <section id="devices" class="three_column"
           data-block="devices"
-          data-source="https://analytics.usa.gov/data/live/devices.json">
+          data-source="{{ site.data_url }}/devices.json">
           <h4>Devices</h4>
           <figure id="chart_device_types">
             <div class="data bar-chart">
@@ -130,14 +134,14 @@
 
           <figure id="chart_browsers"
             data-block="browsers"
-            data-source="https://analytics.usa.gov/data/live/browsers.json">
+            data-source="{{ site.data_url }}/browsers.json">
             <div class="data bar-chart">
             </div>
           </figure>
 
           <figure id="chart_ie"
             data-block="ie"
-            data-source="https://analytics.usa.gov/data/live/ie.json">
+            data-source="{{ site.data_url }}/ie.json">
             <h4>Internet Explorer</h4>
             <div class="data bar-chart">
             </div>
@@ -149,14 +153,14 @@
 
           <figure id="chart_os"
             data-block="os"
-            data-source="https://analytics.usa.gov/data/live/os.json">
+            data-source="{{ site.data_url }}/os.json">
             <div class="data bar-chart">
             </div>
           </figure>
 
           <figure id="chart_windows"
             data-block="windows"
-            data-source="https://analytics.usa.gov/data/live/windows.json">
+            data-source="{{ site.data_url }}/windows.json">
             <h4>Windows</h4>
             <div class="data bar-chart">
             </div>
@@ -177,7 +181,7 @@
 
           <figure class="top-pages" id="top-pages-realtime" role="tabpanel"
             data-block="top-pages-realtime"
-            data-source="https://analytics.usa.gov/data/live/top-pages-realtime.json"
+            data-source="{{ site.data_url }}/top-pages-realtime.json"
             data-refresh="15">
             <h5><strong>Pages</strong><br/>
             <em>People on a single, specific government page now.</em></h5>
@@ -187,7 +191,7 @@
 
           <figure class="top-pages" id="top-pages-7-days" role="tabpanel"
             data-block="top-pages"
-            data-source="https://analytics.usa.gov/data/live/top-domains-7-days.json">
+            data-source="{{ site.data_url }}/top-domains-7-days.json">
             <h5><strong>Domains</strong><br/>
             <em>Total visits over the last week to government domains, which includes traffic to all pages within that domain.</em></h5>
             <div class="data bar-chart">
@@ -196,7 +200,7 @@
 
           <figure class="top-pages" id="top-pages-30-days" role="tabpanel"
             data-block="top-pages"
-            data-source="https://analytics.usa.gov/data/live/top-domains-30-days.json">
+            data-source="{{ site.data_url }}/top-domains-30-days.json">
             <h5><strong>Domains</strong><br/>
               <em>Total visits over the last month to government domains, which includes traffic to all pages within that domain.</em></h5>
             <div class="data bar-chart">
@@ -238,52 +242,52 @@
 
         <ul>
           <li>
-            <a href="https://analytics.usa.gov/data/live/realtime.json">
+            <a href="{{ site.data_url }}/realtime.json">
               People online right now</a>
             (Updated every minute)
           </li>
           <li>
-            <a href="https://analytics.usa.gov/data/live/today.json">
+            <a href="{{ site.data_url }}/today.json">
               Visits every hour today</a>
             (Updated every hour)
           </li>
           <li>
-            <a href="https://analytics.usa.gov/data/live/devices.json">
+            <a href="{{ site.data_url }}/devices.json">
               Visits by desktop/mobile/tablet devices over 90 days</a>
             (Updated every day)
           </li>
           <li>
-            <a href="https://analytics.usa.gov/data/live/os.json">
+            <a href="{{ site.data_url }}/os.json">
               Visits broken down by Operating System over 90 days</a>
             (Updated every day)
           </li>
           <li>
-            <a href="https://analytics.usa.gov/data/live/windows.json">
+            <a href="{{ site.data_url }}/windows.json">
               Visits broken down by Windows version over 90 days</a>
             (Updated every day)
           </li>
           <li>
-            <a href="https://analytics.usa.gov/data/live/browsers.json">
+            <a href="{{ site.data_url }}/browsers.json">
               Visits broken down by browser over 90 days</a>
             (Updated every day)
           </li>
           <li>
-            <a href="https://analytics.usa.gov/data/live/ie.json">
+            <a href="{{ site.data_url }}/ie.json">
               Visits broken down by Internet Explorer version over 90 days</a>
             (Updated every day)
           </li>
           <li>
-            <a href="https://analytics.usa.gov/data/live/top-pages-realtime.json">
+            <a href="{{ site.data_url }}/top-pages-realtime.json">
               Top 20 pages, ranked by visitors online now</a>
             (Updated every minute)
           </li>
           <li>
-            <a href="https://analytics.usa.gov/data/live/top-domains-7-days.json">
+            <a href="{{ site.data_url }}/top-domains-7-days.json">
               Top 20 domains, ranked by visits over 7 days</a>
             (Updated every day)
           </li>
           <li>
-            <a href="https://analytics.usa.gov/data/live/top-domains-30-days.json">
+            <a href="{{ site.data_url }}/top-domains-30-days.json">
               Top 20 domains, ranked by visits over 30 days</a>
             (Updated every day)
           </li>

--- a/index.html
+++ b/index.html
@@ -319,5 +319,6 @@ permalink: /
 
   <script src="/js/index.js"></script>
 
+  <!-- report to oneself -->
   <script id="_fed_an_ua_tag" src="https://analytics.usa.gov/dap/dap.min.js"></script>
 </html>


### PR DESCRIPTION
This moves the site away from purely static HTML and uses Jekyll to build the site into static HTML.

The primary motivator here is so that the site can be easily developed to pull from local data, which was previously hardcoded in like 15 places to be `analytics.usa.gov`. I anticipate that this separation will make the site at least a little easier for others to adapt to their own URLs and circumstances, too.

A new `_development.yml` config file allows someone to build the site to assume that the site is at `localhost:4000` and the data at `localhost:3000` at:

```
bundle exec jekyll serve --watch --config=_config.yml,_development.yml
```

The default `bundle exec jekyll serve` will use the production settings, where everything is assumed to be on `analytics.usa.gov`.

I've rewritten the README to document this and to suggest `serve` as a CORS-enabled data-hosting tool. I've also updated the deployment instructions to deploy the contents of `_site`.