### PR TITLE
Add Google Webmaster Tools verification tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@ permalink: /
 
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+    <meta name="google-site-verification" content="NjbZn6hQe7OwV-nTsa6nLmtrOUcSGPRyFjxm5zkmCcg" />
 
     <link rel="stylesheet" href="/css/public_analytics.css">
 


### PR DESCRIPTION
This lets us get valuable information about how Google sees and indexes analytics.usa.gov. The same verification can be shared to give access to multiple team mambers, so we should only have to do this once.