### PR TITLE
Link to the new SLD CSV

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,7 +219,7 @@ permalink: /
         </p>
 
         <p>
-          Not every government website is represented in this data. Currently, the Digital Analytics Program collects web traffic from over <a href="https://www.digitalgov.gov/files/2012/10/DAP-Domains-and-Agencies-3-2015-Sheet1.csv">300 executive branch government domains</a>, across <a href="https://analytics.usa.gov/data/sites.csv">over 4000 total websites</a>, including every cabinet department. We continue to pursue and add more sites frequently; to add your site, <a href="mailto:DAP@gsa.gov">email the Digital Analytics Program</a>.
+          Not every government website is represented in this data. Currently, the Digital Analytics Program collects web traffic from around <a href="https://analytics.usa.gov/data/live/second-level-domains.csv">400 executive branch government domains</a>, across <a href="https://analytics.usa.gov/data/sites.csv">over 4000 total websites</a>, including every cabinet department. We continue to pursue and add more sites frequently; to add your site, <a href="mailto:DAP@gsa.gov">email the Digital Analytics Program</a>.
         </p>
 
         <p>


### PR DESCRIPTION
This updates the site to link to the new automatically generated/published report of participating second-level domains. It updates daily, along with the other daily reports.