### PR TITLE
Removing blue outline from bars in chart on click

### DIFF
--- a/css/public_analytics.css
+++ b/css/public_analytics.css
@@ -337,6 +337,10 @@ section {
   #chart_ie .bar-chart .bin .bar {
     display: none; }
 
+.bar:focus{
+  outline: 0;
+}
+
 #time_series {
   padding: 0 1em; }
 

--- a/css/public_analytics.css
+++ b/css/public_analytics.css
@@ -338,8 +338,7 @@ section {
     display: none; }
 
 .bar:focus{
-  outline: 0;
-}
+  outline: 0; }
 
 #time_series {
   padding: 0 1em; }


### PR DESCRIPTION
Not sure if this is a feature or a bug, but I find it a bit distracting.