### PR TITLE
Switch to DAP's new central hosting URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -322,5 +322,5 @@ permalink: /
   <script src="/js/index.js"></script>
 
   <!-- report to oneself -->
-  <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js"></script>
+  <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA"></script>
 </html>

--- a/index.html
+++ b/index.html
@@ -322,5 +322,5 @@ permalink: /
   <script src="/js/index.js"></script>
 
   <!-- report to oneself -->
-  <script id="_fed_an_ua_tag" src="https://analytics.usa.gov/dap/dap.min.js"></script>
+  <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js"></script>
 </html>


### PR DESCRIPTION
This changes our DAP embed code to:

```
<script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA"></script>
```

This takes advantage of the DAP's new [centrally hosted JavaScript code](https://www.digitalgov.gov/2015/08/14/secure-central-hosting-for-the-digital-analytics-program/), which means 18f.gsa.gov will automatically get security updates, new features, and other bugfixes automatically.