### PR TITLE
Modify DAP contact address

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,7 +219,7 @@ permalink: /
         </p>
 
         <p>
-          Not every government website is represented in this data. Currently, the Digital Analytics Program collects web traffic from around <a href="https://analytics.usa.gov/data/live/second-level-domains.csv">400 executive branch government domains</a>, across <a href="https://analytics.usa.gov/data/sites.csv">over 4000 total websites</a>, including every cabinet department. We continue to pursue and add more sites frequently; to add your site, <a href="mailto:DAP@gsa.gov">email the Digital Analytics Program</a>.
+          Not every government website is represented in this data. Currently, the Digital Analytics Program collects web traffic from around <a href="https://analytics.usa.gov/data/live/second-level-domains.csv">400 executive branch government domains</a>, across <a href="https://analytics.usa.gov/data/sites.csv">over 4000 total websites</a>, including every cabinet department. We continue to pursue and add more sites frequently; to add your site, <a href="mailto:DAP@support.digitalgov.gov">email the Digital Analytics Program</a>.
         </p>
 
         <p>
@@ -231,7 +231,7 @@ permalink: /
         </p>
 
         <p>
-          We plan to expand the data made available here. If you have any suggestions, or spot any issues or bugs, please <a href="https://github.com/GSA/analytics.usa.gov/issues">open an issue on GitHub</a> or contact the <a href="mailto:DAP@gsa.gov">Digital Analytics Program</a>.
+          We plan to expand the data made available here. If you have any suggestions, or spot any issues or bugs, please <a href="https://github.com/GSA/analytics.usa.gov/issues">open an issue on GitHub</a> or contact the <a href="mailto:DAP@support.digitalgov.gov">Digital Analytics Program</a>.
         </p>
       </section>
 


### PR DESCRIPTION
We moved to dap@support.digitalgov.gov from dap@gsa.gov