### PR TITLE
Revert back to former DAP script

### DIFF
--- a/index.html
+++ b/index.html
@@ -324,5 +324,5 @@ permalink: /
   <script src="/js/index.js"></script>
 
   <!-- report to oneself -->
-  <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA&exts=json"></script>
+  <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA"></script>
 </html>


### PR DESCRIPTION
Something breaking with & in src. Reverting back to old `<script>` without until issue resolved.