### PR TITLE
Add json downloads querystring parameter

### DIFF
--- a/index.html
+++ b/index.html
@@ -324,5 +324,5 @@ permalink: /
   <script src="/js/index.js"></script>
 
   <!-- report to oneself -->
-  <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA"></script>
+  <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA&exts=json"></script>
 </html>


### PR DESCRIPTION
Trying this one more time, I am confident it will resolve. The source path now works:

https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA&exts=json

**diff makes the & white, but it is there.